### PR TITLE
Patch the managed runtime images to remove the remaining brace-expans…

### DIFF
--- a/docker/runtime-core/backend.Dockerfile
+++ b/docker/runtime-core/backend.Dockerfile
@@ -4,9 +4,14 @@ RUN npm install -g npm@11.12.1 \
     && mkdir -p /tmp/npm-runtime-fix \
     && cd /tmp/npm-runtime-fix \
     && npm pack picomatch@4.0.4 \
+    && npm pack brace-expansion@5.0.5 \
     && rm -rf /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch \
+    && rm -rf /usr/local/lib/node_modules/npm/node_modules/brace-expansion \
     && tar -xzf picomatch-4.0.4.tgz \
     && mv package /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch \
+    && mkdir -p /tmp/npm-runtime-fix/brace-expansion \
+    && tar -xzf brace-expansion-5.0.5.tgz -C /tmp/npm-runtime-fix/brace-expansion \
+    && mv /tmp/npm-runtime-fix/brace-expansion/package /usr/local/lib/node_modules/npm/node_modules/brace-expansion \
     && rm -rf /tmp/npm-runtime-fix
 
 FROM python:3.14.3-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca

--- a/docker/runtime-core/node.Dockerfile
+++ b/docker/runtime-core/node.Dockerfile
@@ -6,9 +6,14 @@ RUN npm install -g npm@11.12.1 \
     && mkdir -p /tmp/npm-runtime-fix \
     && cd /tmp/npm-runtime-fix \
     && npm pack picomatch@4.0.4 \
+    && npm pack brace-expansion@5.0.5 \
     && rm -rf /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch \
+    && rm -rf /usr/local/lib/node_modules/npm/node_modules/brace-expansion \
     && tar -xzf picomatch-4.0.4.tgz \
     && mv package /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch \
+    && mkdir -p /tmp/npm-runtime-fix/brace-expansion \
+    && tar -xzf brace-expansion-5.0.5.tgz -C /tmp/npm-runtime-fix/brace-expansion \
+    && mv /tmp/npm-runtime-fix/brace-expansion/package /usr/local/lib/node_modules/npm/node_modules/brace-expansion \
     && rm -rf /tmp/npm-runtime-fix
 
 COPY package.json package-lock.json ./


### PR DESCRIPTION
…ion scanner finding

Carries the brace-expansion 5.0.5 runtime npm patch forward onto the latest sanitized main branch so the backend and frontend images keep the security cleanup without reintroducing the generated-file timestamp noise from the previous local working tree.