### PR TITLE
fix: clean up watchdog launchers and cloud MCP capabilities

### DIFF
--- a/scripts/install-watchdog-autocad-collector-startup.ps1
+++ b/scripts/install-watchdog-autocad-collector-startup.ps1
@@ -371,10 +371,16 @@ $staleLauncherRepairs = Repair-SuiteStaleLauncherTasks `
     -TaskNamePrefixes @("SuiteWatchdogAutoCADCollector-", "SuiteWatchdogAutoCADCollectorCheck-") `
     -KeepTaskNames @($TaskName, $CheckTaskName) `
     -LauncherDirectory $launcherDir `
-    -Comment "Neutralized stale Suite Watchdog AutoCAD startup task launcher."
+    -Comment "Neutralized stale Suite Watchdog AutoCAD startup task launcher." `
+    -DisableTasks
 
 foreach ($repair in @($staleLauncherRepairs)) {
-    Write-Warning "Neutralized stale AutoCAD watchdog startup launcher '$($repair.launcherPath)' still referenced by task '$($repair.taskName)'."
+    if ($repair.taskDisabled) {
+        Write-Warning "Neutralized stale AutoCAD watchdog startup launcher '$($repair.launcherPath)' and disabled task '$($repair.taskName)'."
+    }
+    else {
+        Write-Warning "Neutralized stale AutoCAD watchdog startup launcher '$($repair.launcherPath)' still referenced by task '$($repair.taskName)'."
+    }
 }
 
 if (-not $ForceRunKey) {

--- a/scripts/install-watchdog-filesystem-collector-startup.ps1
+++ b/scripts/install-watchdog-filesystem-collector-startup.ps1
@@ -279,10 +279,16 @@ $staleLauncherRepairs = Repair-SuiteStaleLauncherTasks `
     -TaskNamePrefixes @("SuiteWatchdogFilesystemCollector-", "SuiteWatchdogFilesystemCollectorCheck-") `
     -KeepTaskNames @($TaskName, $CheckTaskName) `
     -LauncherDirectory $launcherDir `
-    -Comment "Neutralized stale Suite Watchdog filesystem startup task launcher."
+    -Comment "Neutralized stale Suite Watchdog filesystem startup task launcher." `
+    -DisableTasks
 
 foreach ($repair in @($staleLauncherRepairs)) {
-    Write-Warning "Neutralized stale filesystem watchdog startup launcher '$($repair.launcherPath)' still referenced by task '$($repair.taskName)'."
+    if ($repair.taskDisabled) {
+        Write-Warning "Neutralized stale filesystem watchdog startup launcher '$($repair.launcherPath)' and disabled task '$($repair.taskName)'."
+    }
+    else {
+        Write-Warning "Neutralized stale filesystem watchdog startup launcher '$($repair.launcherPath)' still referenced by task '$($repair.taskName)'."
+    }
 }
 
 if (-not $ForceRunKey) {

--- a/scripts/suite-runtime-process-utils.ps1
+++ b/scripts/suite-runtime-process-utils.ps1
@@ -109,10 +109,20 @@ function Write-SuiteNoOpLauncher {
         New-Item -ItemType Directory -Path $launcherDirectory -Force | Out-Null
     }
 
+    $commentLines = @()
+    foreach ($commentLine in @(([string]$Comment) -split "\r?\n")) {
+        if ([string]::IsNullOrWhiteSpace($commentLine)) {
+            $commentLines += "'"
+            continue
+        }
+
+        $commentLines += "' " + ([string]$commentLine).Trim()
+    }
+
     $launcherLines = @(
         "Option Explicit",
-        "",
-        "' " + $Comment,
+        ""
+    ) + @($commentLines) + @(
         "WScript.Quit 0"
     )
 
@@ -140,12 +150,20 @@ function Repair-SuiteStaleLauncherTasks {
         [string[]]$TaskNamePrefixes,
         [string[]]$KeepTaskNames,
         [Parameter(Mandatory = $true)][string]$LauncherDirectory,
-        [string]$Comment = "Neutralized stale Suite startup task launcher."
+        [string]$Comment = "Neutralized stale Suite startup task launcher.",
+        [switch]$DisableTasks
     )
 
     $getScheduledTaskCommand = Get-Command Get-ScheduledTask -ErrorAction SilentlyContinue
     if (-not $getScheduledTaskCommand) {
         return @()
+    }
+
+    $disableScheduledTaskCommand = if ($DisableTasks) {
+        Get-Command Disable-ScheduledTask -ErrorAction SilentlyContinue
+    }
+    else {
+        $null
     }
 
     $normalizedLauncherDirectory = [System.IO.Path]::GetFullPath($LauncherDirectory).TrimEnd('\')
@@ -205,10 +223,21 @@ function Repair-SuiteStaleLauncherTasks {
             }
 
             Write-SuiteNoOpLauncher -LauncherPath $normalizedLauncherPath -Comment $Comment | Out-Null
+            $taskDisabled = $false
+            if ($DisableTasks -and $disableScheduledTaskCommand) {
+                try {
+                    Disable-ScheduledTask -TaskName $taskName -ErrorAction Stop | Out-Null
+                    $taskDisabled = $true
+                }
+                catch {
+                    $taskDisabled = $false
+                }
+            }
             $results += [pscustomobject]@{
                 taskName = $taskName
                 launcherPath = $normalizedLauncherPath
                 disabledLauncherPath = $disabledLauncherPath
+                taskDisabled = $taskDisabled
             }
         }
     }

--- a/tools/suite-repo-mcp/server.mjs
+++ b/tools/suite-repo-mcp/server.mjs
@@ -254,6 +254,23 @@ const SUPPORTED_PROTOCOL_VERSIONS = new Set([
 	"2025-06-18",
 	"2024-11-05",
 ]);
+const TOOL_ONLY_CLOUD_AGENT_MODE =
+	String(process.env.SUITE_WORKSTATION_ROLE || "")
+		.trim()
+		.toLowerCase() === "ci" ||
+	String(process.env.SUITE_WORKSTATION_ID || "")
+		.trim()
+		.toUpperCase() === "GITHUB-CLOUD";
+const SERVER_CAPABILITIES = TOOL_ONLY_CLOUD_AGENT_MODE
+	? {
+			tools: {},
+		}
+	: {
+			tools: {},
+			prompts: {},
+			resources: {},
+			logging: {},
+		};
 
 const MAX_OUTPUT_CHARS = 200_000;
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -3639,12 +3656,7 @@ async function handleRequest(message) {
 				: LATEST_PROTOCOL_VERSION;
 			return sendResponse(id, {
 				protocolVersion,
-				capabilities: {
-					tools: {},
-					prompts: {},
-					resources: {},
-					logging: {},
-				},
+				capabilities: SERVER_CAPABILITIES,
 				serverInfo: SERVER_INFO,
 			});
 		}
@@ -3667,18 +3679,27 @@ async function handleRequest(message) {
 		}
 
 		if (method === "resources/list") {
+			if (TOOL_ONLY_CLOUD_AGENT_MODE) {
+				return sendError(id, -32601, "Method not found: resources/list");
+			}
 			return sendResponse(id, {
 				resources: resourceList(),
 			});
 		}
 
 		if (method === "resources/templates/list") {
+			if (TOOL_ONLY_CLOUD_AGENT_MODE) {
+				return sendError(id, -32601, "Method not found: resources/templates/list");
+			}
 			return sendResponse(id, {
 				resourceTemplates: [],
 			});
 		}
 
 		if (method === "resources/read") {
+			if (TOOL_ONLY_CLOUD_AGENT_MODE) {
+				return sendError(id, -32601, "Method not found: resources/read");
+			}
 			const uri = params?.uri;
 			if (typeof uri !== "string") {
 				return sendError(id, -32602, "resources/read requires a string uri");
@@ -3729,12 +3750,18 @@ async function handleRequest(message) {
 		}
 
 		if (method === "prompts/list") {
+			if (TOOL_ONLY_CLOUD_AGENT_MODE) {
+				return sendError(id, -32601, "Method not found: prompts/list");
+			}
 			return sendResponse(id, {
 				prompts: promptList(),
 			});
 		}
 
 		if (method === "prompts/get") {
+			if (TOOL_ONLY_CLOUD_AGENT_MODE) {
+				return sendError(id, -32601, "Method not found: prompts/get");
+			}
 			const name = params?.name;
 			const rawArgs = params?.arguments;
 			if (typeof name !== "string") {


### PR DESCRIPTION
## Summary
- repair stale watchdog launcher neutralization so old DUSTIN-HOME tasks no longer trigger VBScript popups
- teach watchdog startup installers to attempt disabling stale launcher tasks on future runs
- advertise suite-repo-mcp as tools-only in GitHub cloud/CI sessions to avoid unsupported MCP capabilities in hosted Copilot runs

## Verification
- `node --check tools/suite-repo-mcp/server.mjs`
- PowerShell parser check for the three updated `.ps1` files
- manual local verification already performed for repaired no-op launchers and stale task runs
